### PR TITLE
Roll back version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpad-plugin-sunny",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "DocPad plugin which adds the ability to output to Amazon S3, Google Storage or and other service supported by SunnyJS.",
   "homepage": "https://github.com/bobobo1618/docpad-plugin-sunny",
   "keywords": [


### PR DESCRIPTION
Sorry it took me a few days to get to this. I unpublished 3.0.0 from npm since no one can use it as-is, I bumped the version to 2.1.0, and I published that to npm. This change set is just for the version rollback.

Fixes https://github.com/bobobo1618/docpad-plugin-sunny/issues/14
